### PR TITLE
feat: add UUID-based `id` to the generated Thing Description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+ "rand",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,6 +2239,7 @@ dependencies = [
  "mdns-sd",
  "serde_json",
  "tokio",
+ "uuid",
  "wot-td",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,9 @@ serde_json = "1.0.132"
 tokio = "1.41.0"
 wot-td = "0.5.0"
 
+[dependencies.uuid]
+version = "1.11.0"
+features = [
+    "v4",
+    "fast-rng",
+]

--- a/src/coap.rs
+++ b/src/coap.rs
@@ -3,8 +3,12 @@
 use coap::Server;
 use coap_lite::{CoapRequest, ContentFormat, MessageClass, RequestType as Method, ResponseType};
 use std::net::SocketAddr;
+use std::sync::LazyLock;
 use tokio::runtime::Runtime;
+use uuid::Uuid;
 use wot_td::Thing;
+
+static TD_UUID: LazyLock<uuid::Uuid> = LazyLock::new(Uuid::new_v4);
 
 pub(crate) fn create_coap_server() {
     let addr = "0.0.0.0:5683";
@@ -42,6 +46,7 @@ fn create_td_payload() -> Vec<u8> {
 
     let thing_description = Thing::builder("Example Thing")
         .security(|builder| builder.no_sec().with_key("nosec_sc").required())
+        .id(TD_UUID.urn().to_string())
         .build()
         .expect("TD should be valid");
 


### PR DESCRIPTION
While testing with another application, I've noticed that the TD generated by the implementation has not contained a proper ID so far. This PR changes that by leveraging the `uuid` crate.